### PR TITLE
memcpy bug

### DIFF
--- a/src/EloquentTinyML.h
+++ b/src/EloquentTinyML.h
@@ -100,7 +100,7 @@ namespace Eloquent {
                 if (!initialized())
                     return sqrt(-1);
 
-                memcpy(input, this->input->data.uint8, sizeof(uint8_t) * inputSize);
+                memcpy(this->input->data.uint8,input,sizeof(uint8_t) * inputSize);
 
                 if (interpreter->Invoke() != kTfLiteOk) {
                     reporter->Report("Inference failed");


### PR DESCRIPTION

The source and destination were flipped. 

Memcpy API - 
void *memcpy(void *dest, const void * src, size_t n)

Link - 
https://www.tutorialspoint.com/c_standard_library/c_function_memcpy.htm